### PR TITLE
check test skip

### DIFF
--- a/tests/test_nameguard.py
+++ b/tests/test_nameguard.py
@@ -50,3 +50,24 @@ def test_highest_risk(nameguard: NameGuard):
     result = nameguard.inspect_name('nić_k.eth')
     assert result.summary.highest_risk.check is Check.NORMALIZED
     assert result.summary.highest_risk.rating is Rating.ALERT
+
+
+def test_check_skip(nameguard: NameGuard):
+    sup = 'a'
+    unsup = chr(2045)
+    unk = '\u0378'
+
+    result = nameguard.inspect_name(sup)
+    c = [c for c in result.checks if c.check is Check.FONT_SUPPORT][0]
+    assert c.rating is Rating.PASS
+    assert c.status is CheckStatus.PASS
+
+    result = nameguard.inspect_name(unsup)
+    c = [c for c in result.checks if c.check is Check.FONT_SUPPORT][0]
+    assert c.rating is Rating.WARN
+    assert c.status is CheckStatus.WARN
+
+    result = nameguard.inspect_name(unk)
+    c = [c for c in result.checks if c.check is Check.FONT_SUPPORT][0]
+    assert c.rating is Rating.PASS
+    assert c.status is CheckStatus.SKIP


### PR DESCRIPTION
Skipping works properly. A check can decide that it cannot run and its status becomes `SKIP`.
Checks that `SKIP` are treated as if they `PASS` when calculating the name `Rating`.
So they do not contribute to the name rating but still show up in the `checks` list of the response.
<img width="648" alt="image" src="https://github.com/namehash/nameguard/assets/29494629/63c0a659-bd15-4d61-b031-ef29041cf718">
