### PR TITLE
fix infinite loading on nameguard homepage

### DIFF
--- a/apps/nameguard.io/src/components/organisms/Hero.tsx
+++ b/apps/nameguard.io/src/components/organisms/Hero.tsx
@@ -87,11 +87,7 @@ export function Hero() {
         </p>
         <div className="relative overflow-x-hidden w-full h-10 group">
           <div className="z-10 absolute top-0 w-full h-full pointer-events-none shadow-[inset_45px_0_25px_-20px_rgba(249,250,251,0.97),inset_-45px_0_25px_-20px_rgba(249,250,251,0.97)]"></div>
-          <Suspense
-            fallback={<div className="bg-gray-100 rounded-md h-8 w-full"></div>}
-          >
-            <HeroCarousel />
-          </Suspense>
+          <HeroCarousel />
         </div>
       </div>
     </div>

--- a/apps/nameguard.io/src/components/organisms/HeroCarousel.tsx
+++ b/apps/nameguard.io/src/components/organisms/HeroCarousel.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { nameguard } from "@namehash/nameguard";
+import React, { useEffect, useState } from "react";
+import {
+  BulkConsolidatedNameGuardReport,
+  nameguard,
+} from "@namehash/nameguard";
 import { buildENSName } from "@namehash/ens-utils";
 import { ReportModalNameBadge } from "@namehash/nameguard-react";
 
@@ -37,13 +41,26 @@ const examples = [
   "7️⃣7️⃣7️⃣.eth",
 ];
 
-export async function HeroCarousel() {
+export function HeroCarousel() {
+  const [data, setData] = useState<BulkConsolidatedNameGuardReport>();
   const ensNames = examples.map((n) => buildENSName(n));
-  const data = await nameguard.bulkInspectNames(examples);
+
+  useEffect(() => {
+    async function fetchData() {
+      const result = await nameguard.bulkInspectNames(examples);
+      setData(result);
+    }
+
+    fetchData();
+  }, []);
+
+  if (!data) {
+    return <div className="bg-gray-100 rounded-md h-8 w-full"></div>;
+  }
 
   return (
     <div className="w-[200%] group flex flex-nowrap justify-center items-center space-x-1 animate-carousel group-hover:pause-on-hover">
-      {/* 
+      {/*
         This carousel component needs lots of badges in order
         to look good in the Ui, we are, then, duplicating the
         badges displayed to enhance badges number.
@@ -55,7 +72,7 @@ export async function HeroCarousel() {
           ensName={ensNames[index]}
         />
       ))}
-      {/* 
+      {/*
         This carousel component needs lots of badges in order
         to look good in the Ui, we are, then, duplicating the
         badges displayed to enhance badges number.


### PR DESCRIPTION
I noticed the following error on the homepage causing some infinite loading and blocking IO:

```
Error: async/await is not yet supported in Client Components, only Server Components. This error is often caused by accidentally adding `'use client'` to a module that was originally written for the server.
```