### PR TITLE
Resolve tailwind warning

### DIFF
--- a/apps/nameguard.io/tailwind.config.ts
+++ b/apps/nameguard.io/tailwind.config.ts
@@ -6,7 +6,7 @@ const config: Config = {
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/*.{js,ts,jsx,tsx,mdx}",
-    "./node_modules/@namehash/nameguard-react/**/*.{js,jsx,ts,tsx}",
+    "../../packages/nameguard-react/src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
![CleanShot 2024-09-19 at 00 35 03](https://github.com/user-attachments/assets/a3dddc18-257e-45c5-8bd3-0086effad12e)

This PR removes the build warning above.

I'm curious why we need this line at all though? Should we just entirely remove it?