### PR TITLE
Release changes

### DIFF
--- a/.changeset/five-cameras-act.md
+++ b/.changeset/five-cameras-act.md
@@ -1,5 +1,0 @@
----
-"nameguard-api": patch
----
-
-Initial package definition for NameGuard API

--- a/.changeset/thin-plums-build.md
+++ b/.changeset/thin-plums-build.md
@@ -1,0 +1,11 @@
+---
+"@namekit/tsconfig": minor
+"@namehash/ens-utils": minor
+"@namehash/ens-webfont": minor
+"@namehash/nameguard-js": minor
+"@namehash/nameguard-react": minor
+"@namehash/nameguard": minor
+"@namehash/namekit-react": minor
+---
+
+release


### PR DESCRIPTION
Removes the chansgeset for `nameguard-api` which is also removed @lightwalker-eth 