### PR TITLE
fix: use decodedName

### DIFF
--- a/apps/nameguard.io/src/app/inspect/[name]/page.tsx
+++ b/apps/nameguard.io/src/app/inspect/[name]/page.tsx
@@ -36,7 +36,7 @@ export default async function Namekit({ params }: Props) {
 
   return (
     <div className="max-w-7xl mx-auto p-6 py-12">
-      <NGReport name={name} data={report} />
+      <NGReport name={decodedName} data={report} />
     </div>
   );
 }


### PR DESCRIPTION
Fixes the issue on the inspect page where the decoded name wasn't passed to the `NGReport`.

No changeset required since this is an app fix.

![CleanShot 2024-10-08 at 14 37 17@2x](https://github.com/user-attachments/assets/f1e610d6-8ed4-4c2b-bded-f6ed6b3f66e7)
