### PR TITLE
feat(namekit-react): Identity

### DIFF
--- a/apps/storybook.namekit.io/stories/Namekit/Identity.stories.tsx
+++ b/apps/storybook.namekit.io/stories/Namekit/Identity.stories.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Identity } from "@namehash/namekit-react";
+
+const meta: Meta<typeof Identity.Root> = {
+  title: "Namekit/Identity",
+  component: Identity.Root,
+  argTypes: {
+    address: { control: "text" },
+    network: {
+      control: {
+        type: "select",
+        options: ["mainnet", "sepolia"],
+      },
+    },
+    className: { control: "text" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Identity.Root>;
+
+const IdentityCard: React.FC<{
+  address: string;
+  network?: "mainnet" | "sepolia";
+}> = ({ address, network }) => (
+  <Identity.Root address={address} network={network}>
+    <Identity.Avatar />
+    <Identity.Name />
+    <Identity.Address />
+    <Identity.NameGuardShield />
+  </Identity.Root>
+);
+
+export const Default: Story = {
+  args: {
+    address: "0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9",
+    network: "mainnet",
+    className: "rounded-xl",
+  },
+  render: (args) => <IdentityCard {...args} />,
+};
+
+export const MultipleCards: Story = {
+  render: () => (
+    <>
+      <IdentityCard address="0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9" />
+      <IdentityCard address="0x123456789abcdef123456789abcdef123456789a" />
+      <IdentityCard address="0xabcdef123456789abcdef123456789abcdef1234" />
+      <IdentityCard address="0x987654321fedcba987654321fedcba987654321f" />
+      <IdentityCard
+        address="0xfedcba987654321fedcba987654321fedcba9876"
+        network="sepolia"
+      />
+      <IdentityCard address="0x111222333444555666777888999000aaabbbcccd" />
+    </>
+  ),
+};

--- a/packages/namekit-react/package.json
+++ b/packages/namekit-react/package.json
@@ -43,6 +43,7 @@
     "@headlessui/react": "1.7.17",
     "@namehash/ens-utils": "workspace:*",
     "@namehash/ens-webfont": "workspace:*",
+    "@namehash/nameguard": "workspace:*",
     "classcat": "5.0.5"
   },
   "devDependencies": {

--- a/packages/namekit-react/src/components/Identity.tsx
+++ b/packages/namekit-react/src/components/Identity.tsx
@@ -1,0 +1,145 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from "react";
+import {
+  createClient,
+  Network,
+  type SecurePrimaryNameResult,
+} from "@namehash/nameguard";
+
+interface IdentityContextType extends SecurePrimaryNameResult {
+  address: string;
+}
+
+const IdentityContext = createContext<IdentityContextType | null>(null);
+
+const useIdentity = () => {
+  const context = useContext(IdentityContext);
+
+  if (!context) {
+    throw new Error("useIdentity must be used within an IdentityProvider");
+  }
+
+  return context;
+};
+
+interface SubComponentProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+interface RootProps {
+  address: string;
+  network?: Network;
+  className?: string;
+  children: ReactNode;
+}
+
+const Root = ({
+  address,
+  network = "mainnet",
+  className,
+  children,
+  ...props
+}: RootProps) => {
+  const [data, setData] = useState<IdentityContextType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+
+        const nameguard = createClient({ network });
+
+        const result = await nameguard.getSecurePrimaryName(address, {
+          returnNameGuardReport: true,
+        });
+
+        setData({ ...result, address });
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "An unknown error occurred",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [address, network]);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error}</div>;
+  if (!data) return null;
+
+  return (
+    <IdentityContext.Provider value={data}>
+      <div className={`namekit-identity ${className}`} {...props}>
+        {children}
+      </div>
+    </IdentityContext.Provider>
+  );
+};
+
+const Avatar = ({ className, children, ...props }: SubComponentProps) => {
+  const { display_name } = useIdentity();
+
+  return (
+    <div className={`namekit-avatar ${className}`} {...props}>
+      <img
+        src={`https://avatar.example.com/${display_name}`}
+        alt={display_name}
+      />
+      {children}
+    </div>
+  );
+};
+
+const Name = ({ className, ...props }: SubComponentProps) => {
+  const { display_name } = useIdentity();
+
+  return (
+    <div className={`namekit-name ${className}`} {...props}>
+      {display_name}
+    </div>
+  );
+};
+
+const Address = ({ className, ...props }: SubComponentProps) => {
+  const { address } = useIdentity();
+
+  return (
+    <div className={`namekit-address ${className}`} {...props}>
+      {address}
+    </div>
+  );
+};
+
+const NameGuardShield = ({ className, ...props }: SubComponentProps) => {
+  const { nameguard_report } = useIdentity();
+
+  return (
+    <div className={`namekit-nameguard-shield ${className}`} {...props}>
+      <div className="namekit-nameguard-rating">
+        Rating: {nameguard_report?.rating}
+      </div>
+      <div className="namekit-nameguard-risk-count">
+        Risks: {nameguard_report?.risk_count}
+      </div>
+    </div>
+  );
+};
+
+export const Identity = {
+  Root,
+  Avatar,
+  Name,
+  Address,
+  NameGuardShield,
+};

--- a/packages/namekit-react/src/index.ts
+++ b/packages/namekit-react/src/index.ts
@@ -13,3 +13,4 @@ export { ENSTextArea } from "./components/ENSTextArea";
 export { Input } from "./components/Input";
 export { ENSInput } from "./components/ENSInput";
 export { Link } from "./components/Link";
+export { Identity } from "./components/Identity";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,6 +568,9 @@ importers:
       '@namehash/ens-webfont':
         specifier: workspace:*
         version: link:../ens-webfont
+      '@namehash/nameguard':
+        specifier: workspace:*
+        version: link:../nameguard-sdk
       classcat:
         specifier: 5.0.5
         version: 5.0.5
@@ -3548,6 +3551,7 @@ packages:
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   esniff@1.1.3:
@@ -7591,7 +7595,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -7762,7 +7766,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -9023,7 +9027,7 @@ snapshots:
       '@typescript-eslint/types': 8.8.1
       '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 8.8.1
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.2
@@ -9049,7 +9053,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.8.0(typescript@5.6.2)
       '@typescript-eslint/utils': 8.8.0(eslint@8.57.1)(typescript@5.6.2)
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
       typescript: 5.6.2
@@ -9082,7 +9086,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.8.0
       '@typescript-eslint/visitor-keys': 8.8.0
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -9097,7 +9101,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.8.1
       '@typescript-eslint/visitor-keys': 8.8.1
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -9917,19 +9921,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.3.4:
-    dependencies:
-      ms: 2.1.2
-
   debug@4.3.4(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
     optionalDependencies:
       supports-color: 8.1.1
-
-  debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
 
   debug@4.3.7(supports-color@8.1.1):
     dependencies:
@@ -10332,7 +10328,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.1)
       eslint-plugin-react: 7.34.1(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -10355,8 +10351,8 @@ snapshots:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.16.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -10369,10 +10365,10 @@ snapshots:
 
   eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1):
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.16.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
@@ -10384,7 +10380,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -10395,7 +10391,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -10406,7 +10402,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -10416,7 +10412,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10443,7 +10439,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10526,7 +10522,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -13282,7 +13278,7 @@ snapshots:
   vite-node@2.1.2(@types/node@22.7.4):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       pathe: 1.1.2
       vite: 5.1.7(@types/node@22.7.4)
     transitivePeerDependencies:
@@ -13347,7 +13343,7 @@ snapshots:
       '@vitest/spy': 2.1.2
       '@vitest/utils': 2.1.2
       chai: 5.1.1
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       magic-string: 0.30.11
       pathe: 1.1.2
       std-env: 3.7.0


### PR DESCRIPTION
This PR adds a preview for the mechanics of the `<Identity />` component. You can see a preview of it here:

https://github.com/user-attachments/assets/47096a1a-d447-42ff-b040-cba7bce0ba4b

Keep in mind that this is a technical preview, and no styling has been implemented yet, and I won't spend time on the styles until we know we are fetching all the data we want, and the DSL is nice.

One thing I dislike about PR is it now adds as a dependency `@namehash/nameguard`. Instead, I would prefer this to be a peer dependency, and anyone wanting to use this component should install `@namehash/nameguard` AND `@namehash/namekit-react`.