### PR TITLE
feat: [SC-25948] :sparkles: Add new endpoint to NameGraph: fetchTopCollectionMembers

### DIFF
--- a/.changeset/chilly-months-move.md
+++ b/.changeset/chilly-months-move.md
@@ -1,0 +1,5 @@
+---
+"@namehash/namegraph-sdk": minor
+---
+
+Add new endpoint to NameGraph: fetchTopCollectionMembers

--- a/packages/namegraph-sdk/src/index.ts
+++ b/packages/namegraph-sdk/src/index.ts
@@ -35,9 +35,25 @@ export interface NameGraphCategory {
   suggestions: NameGraphSuggestion[];
 }
 
+export interface NameGraphRelatedCollectionsSummarizedResponse {
+  collection_id: string;
+  collection_title: string;
+  collection_members_count: number;
+}
+
 export interface NameGraphNamesGeneratedGroupedByCategoryResponse {
   categories: NameGraphCategory[];
   all_tokenizations: [];
+}
+
+export interface NameGraphFetchTopCollectionMembersResponse {
+  suggestions: NameGraphSuggestion[];
+  name: string;
+  type: string;
+  collection_id: string;
+  collection_title: string;
+  collection_members_count: string;
+  related_collections: NameGraphRelatedCollectionsSummarizedResponse[];
 }
 
 export interface NameGraphCountCollectionsResponse {
@@ -160,6 +176,21 @@ export class NameGraph {
     };
 
     return this.rawRequest(`grouped-by-category`, "POST", payload);
+  }
+
+  public fetchTopCollectionMembers(
+    collection_id: string,
+  ): Promise<NameGraphFetchTopCollectionMembersResponse> {
+    const metadata = true;
+    const max_recursive_related_collections = 3;
+
+    const payload = {
+      metadata,
+      collection_id,
+      max_recursive_related_collections,
+    };
+
+    return this.rawRequest("fetch_top_collection_members", "POST", payload);
   }
 
   public countCollectionsByString(


### PR DESCRIPTION
This PR addresses the addition of the following items:

- `/fetch-top-collection-members` NameGraph endpoint
- All interfaces related to it

The interfaces were mirrored from the following reference:
- http://100.24.45.225/docs