### PR TITLE
feat: [SC-25948] :sparkles: Add new endpoint to NameGraph: sampleCollectionMembers

### DIFF
--- a/.changeset/nervous-roses-explain.md
+++ b/.changeset/nervous-roses-explain.md
@@ -1,0 +1,5 @@
+---
+"@namehash/namegraph-sdk": minor
+---
+
+Add new endpoint to NameGraph: sampleCollectionMembers

--- a/packages/namegraph-sdk/src/index.ts
+++ b/packages/namegraph-sdk/src/index.ts
@@ -162,6 +162,23 @@ export class NameGraph {
     return this.rawRequest(`grouped-by-category`, "POST", payload);
   }
 
+  public sampleCollectionMembers(
+    collection_id: string,
+  ): Promise<NameGraphSuggestion[]> {
+    const metadata = true;
+    const max_sample_size = 5;
+    const seed = 5;
+
+    const payload = {
+      collection_id,
+      metadata,
+      max_sample_size,
+      seed,
+    };
+
+    return this.rawRequest("sample_collection_members", "POST", payload);
+  }
+
   public countCollectionsByString(
     query: string,
   ): Promise<NameGraphCountCollectionsResponse> {


### PR DESCRIPTION
This PR addresses the addition of the following items:

- `/sample_collections_members` NameGraph endpoint
- All interfaces related to it

The interfaces were mirrored from the following reference:
- http://100.24.45.225/docs