### PR TITLE
feat: [SC-25948] ✨ Add new endpoint to NameGraph: scrambleCollectionTokens

### DIFF
--- a/.changeset/hip-cherries-bow.md
+++ b/.changeset/hip-cherries-bow.md
@@ -1,0 +1,5 @@
+---
+"@namehash/namegraph-sdk": minor
+---
+
+Add new endpoint to NameGraph: scrambleCollectionTokens

--- a/packages/namegraph-sdk/src/index.ts
+++ b/packages/namegraph-sdk/src/index.ts
@@ -162,6 +162,27 @@ export class NameGraph {
     return this.rawRequest(`grouped-by-category`, "POST", payload);
   }
 
+  public scrambleCollectionTokens(
+    collection_id: string,
+  ): Promise<NameGraphSuggestion[]> {
+    const metadata = true;
+    const method = "left-right-shuffle-with-unigrams";
+    const n_top_members = 25;
+    const max_suggestions = 10;
+    const seed = 0;
+
+    const payload = {
+      collection_id,
+      metadata,
+      method,
+      n_top_members,
+      max_suggestions,
+      seed,
+    };
+
+    return this.rawRequest("scramble_collection_tokens", "POST", payload);
+  }
+
   public countCollectionsByString(
     query: string,
   ): Promise<NameGraphCountCollectionsResponse> {


### PR DESCRIPTION
This PR addresses the addition of the following items:

- `/scramble_collection_tokens` NameGraph endpoint
- All interfaces related to it

The interfaces were mirrored from the following reference:
- http://100.24.45.225/docs