### PR TITLE
feat: [SC-25948] ✨ Add new endpoint to NameGraph: findCollectionsByMember

### DIFF
--- a/.changeset/ninety-lies-rest.md
+++ b/.changeset/ninety-lies-rest.md
@@ -1,0 +1,5 @@
+---
+"@namehash/namegraph-sdk": minor
+---
+
+Add new endpoint to NameGraph: findCollectionsByMember

--- a/packages/namegraph-sdk/src/index.ts
+++ b/packages/namegraph-sdk/src/index.ts
@@ -50,6 +50,16 @@ export interface NameGraphCountCollectionsResponse {
   count: number;
 }
 
+export interface NameGraphCollectionsByMemberResponse {
+  metadata: {
+    total_number_of_matched_collections: number;
+    processing_time_ms: number;
+    elasticsearch_processing_time_ms: number;
+    elasticsearch_communication_time_ms: number;
+  };
+  collections: NameGraphSuggestion[];
+}
+
 export interface NameGraphOptions {
   namegraphEndpoint?: string;
 }
@@ -173,6 +183,27 @@ export class NameGraph {
     };
 
     return this.rawRequest("count_collections_by_string", "POST", payload);
+  }
+
+  public findCollectionsByMember(
+    label: string,
+  ): Promise<NameGraphCollectionsByMemberResponse> {
+    const mode = "instant";
+    const limit_names = 10;
+    const offset = 0;
+    const sort_order = "AI";
+    const max_results = 3;
+
+    const payload = {
+      limit_names,
+      offset,
+      sort_order,
+      label,
+      mode,
+      max_results,
+    };
+
+    return this.rawRequest("find_collections_by_member", "POST", payload);
   }
 
   async rawRequest(


### PR DESCRIPTION
This PR addresses the addition of the following items:

- `/find_collections_by_member` NameGraph endpoint
- All interfaces related to it

The interfaces were mirrored from the following reference:
- http://100.24.45.225/docs