### PR TITLE
feat: use default namerank api endpoint

### DIFF
--- a/apps/namerank.io/app/results.tsx
+++ b/apps/namerank.io/app/results.tsx
@@ -1,10 +1,5 @@
-import { createClient } from "@namehash/namerank";
+import { namerank } from "@namehash/namerank";
 import { Indicator } from "./indicator";
-
-const namerank = createClient({
-  namerankEndpoint:
-    "https://izzkysqb6d6qzhnpv4ybqyty2e0ktjwe.lambda-url.us-east-1.on.aws/namerank",
-});
 
 interface ResultsProps {
   name: string;

--- a/packages/namerank-sdk/src/index.ts
+++ b/packages/namerank-sdk/src/index.ts
@@ -69,7 +69,6 @@ export class NameRank {
     network = DEFAULT_NETWORK,
   }: NameRankOptions = {}) {
     this.namerankEndpoint = new URL(namerankEndpoint);
-    console.log(this.namerankEndpoint);
     this.network = network;
     this.abortController = new AbortController();
   }
@@ -126,7 +125,6 @@ export class NameRank {
       options.body = JSON.stringify(body);
     }
 
-    console.log(url);
     const response = await fetch(url, options);
 
     if (!response.ok) {


### PR DESCRIPTION
Additionally removes `console.log` inside the client. Logging is useful, so we should add the ability to do better logging in all our SDKs with some kind of `debug` flag.