### PR TITLE
chore: add ensawards.org to allowed origins

### DIFF
--- a/apps/namehashlabs.org/middleware.ts
+++ b/apps/namehashlabs.org/middleware.ts
@@ -4,6 +4,7 @@ const allowedOrigins = [
   "https://namehashlabs.org",
   "https://www.nameguard.io",
   "https://www.namekit.io",
+  "https://ensawards.org"
 ];
 
 const corsOptions = {


### PR DESCRIPTION
Addittion of ensawards.org to request origins accepted by the page's CORS policy